### PR TITLE
Upgrade bindgen

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,7 @@ jobs:
 
   sys-macos:
     strategy:
+      fail-fast: false
       matrix:
         feature: [
           AGL,
@@ -110,7 +111,6 @@ jobs:
           HealthKit,
           Hypervisor,
           ICADevices,
-          IMServicePlugIn,
           IOBluetooth,
           IOBluetoothUI,
           IOKit,
@@ -124,7 +124,6 @@ jobs:
           InstantMessage,
           Intents,
           IntentsUI,
-          JavaNativeFoundation,
           JavaRuntimeSupport,
           JavaScriptCore,
           Kerberos,
@@ -247,11 +246,11 @@ jobs:
           AssetsLibrary,
           AudioToolbox,
           AudioUnit,
-          AuthenticationServices,
+          # AuthenticationServices,
           AutomaticAssessmentConfiguration,
           BackgroundAssets,
           BackgroundTasks,
-          BusinessChat,
+          # BusinessChat,
           CFNetwork,
           CallKit,
           CarPlay,
@@ -288,7 +287,6 @@ jobs:
           DeviceDiscoveryExtension,
           EventKit,
           EventKitUI,
-          ExposureNotification,
           ExtensionFoundation,
           ExtensionKit,
           ExternalAccessory,

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -14,7 +14,7 @@ include = ["*.toml", "/src"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bindgen = "0.69"
+bindgen = "0.72.1"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.6"
 derive_more = { version = "0.99" }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded a build-time codegen dependency to a newer patch release to stay current; no user-facing behavior changes.
  * Updated CI matrix for macOS/iOS: disabled fail-fast for macOS, removed several platform targets, and commented/disabled a few platform-specific checks to streamline CI runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->